### PR TITLE
Node.js: add hapi 17 support + httptrap.js cleanup and testing

### DIFF
--- a/nodejs/hapi/index.js
+++ b/nodejs/hapi/index.js
@@ -1,0 +1,54 @@
+'use strict';
+const makeTrap = require('../httptrap');
+const pkg = require('../package.json');
+const startSymbol = Symbol('circonusStartTime');
+function noop() {}
+
+
+function register(server, options) {
+  const trap = makeTrap(options.uuid, options.secret, options);
+
+  if (options.onError) {
+    trap.on('error', options.onError);
+  } else {
+    trap.on('error', noop);
+  }
+
+  trap.publish();
+
+  server.decorate('server', 'httptrap', trap);
+  server.decorate('request', startSymbol, null);
+
+  server.ext('onRequest', (request, h) => {
+    request[startSymbol] = process.hrtime();
+    return h.continue;
+  });
+
+  server.ext('onPreResponse', (request, h) => {
+    if (request[startSymbol]) {
+      const specials = request._core.router.specials;
+      const route = request._route;
+      let path;
+
+      if (route === specials.notFound.route) {
+        path = '{notFound*}';
+      } else if (specials.options && route === specials.options.route) {
+        path = '{cors*}';
+      } else if (route.path === '/' && route.method === 'options') {
+        path = '{cors*}';
+      } else {
+        path = route.path;
+      }
+
+      const statName = 'hapi`' + request.method.toUpperCase() + '`' +
+                       path + '`latency';
+      const duration = process.hrtime(request[startSymbol]);
+      trap.record(statName, duration[0] + duration[1] * 1e-9);
+    }
+
+    return h.continue;
+  });
+};
+
+
+module.exports = { register, pkg };

--- a/nodejs/hapi/legacy.js
+++ b/nodejs/hapi/legacy.js
@@ -1,7 +1,7 @@
 // Copyright(c) 2013 Mac Angell
 // Copyright(c) 2016 Circonus, Inc.
 module.exports.register = function (server, options, next) {
-  var makeTrap = require('./httptrap'),
+  var makeTrap = require('../httptrap'),
     path = require('path'),
     trap = makeTrap(options.uuid, options.secret, options),
     normalizePath = function(path) { return path };
@@ -44,5 +44,5 @@ module.exports.register = function (server, options, next) {
 };
 
 module.exports.register.attributes = {
-  pkg: require('./package.json')
+  pkg: require('../package.json')
 };

--- a/nodejs/httptrap.js
+++ b/nodejs/httptrap.js
@@ -1,167 +1,226 @@
-var util=require("util"),
-    os=require("os"),
-    https=require("https"),
-    events = require("events"),
-    hostname = os.hostname(),
-    trap, traps = {};
+'use strict';
+const https = require('https');
+const EventEmitter = require('events');
+const traps = {};
+const defaultBroker = 'trap.noit.circonus.net';
+let defaultCa;
 
-var defaultBroker = 'trap.noit.circonus.net';
 
-trap = function(uuid, secret, options) {
-  if(!options) options = {};
-  this.uuid = uuid;
-  this.secret = secret;
-  this.broker = options.broker || defaultBroker;
-  this.throwErrors = options.throwErrors;
-  this.data = {}
-}
-util.inherits(trap, events.EventEmitter);
+class Trap extends EventEmitter {
+  constructor(uuid, secret, options) {
+    super();
 
-function target(uuid, secret, options) {
-  var key = uuid + '/' + secret;
-  if(options && options.broker) {
-    key = key + '/' + options.broker;
+    if (!options) {
+      options = {};
+    }
+
+    this.uuid = uuid;
+    this.secret = secret;
+    this.broker = options.broker || defaultBroker;
+    this.throwErrors = options.throwErrors;
+    this.data = {}
+    this._pubint = undefined;
   }
-  if(traps.hasOwnProperty(key)) return traps[key];
-  traps[key] = new trap(uuid, secret, options);
-  return traps[key];
-}
 
-function collapse(obj) {
-  var newobj = {};
-  for(var k in obj) {
-    if(obj.hasOwnProperty(k)) {
-      var v = obj[k];
-      if(k === '_value' && typeof(v) === 'object') {
-        var arr_replace = [];
-        for(var hkey in v) {
-          if(v.hasOwnProperty(hkey)) arr_replace.push('' + hkey + '=' + v[hkey]);
-        }
-        newobj[k] = arr_replace;
-      }
-      else if(typeof(v) === 'object') {
-        newobj[k] = collapse(v);
-      }
-      else
-        newobj[k] = v;
+  record(endpoint, value) {
+    const data = this.data;
+
+    if (!data.hasOwnProperty(endpoint)) {
+      data[endpoint] = { '_type': 'n', '_value': {} };
+    }
+
+    const vString = normalize(value);
+
+    if (!data[endpoint]._value.hasOwnProperty(vString)) {
+      data[endpoint]._value[vString] = 1;
+    } else {
+      data[endpoint]._value[vString] = data[endpoint]._value[vString] + 1;
     }
   }
+
+  publish(interval) {
+    if (interval !== 0 && !interval) {
+      interval = 500;
+    }
+
+    if (this._pubint !== undefined) {
+      clearInterval(this._pubint);
+    }
+
+    if (interval != 0) {
+      this._pubint = setInterval(() => {
+        this.push();
+      }, interval);
+    }
+  }
+
+  push() {
+    let b = this.data;
+    const keys = Object.keys(b);
+
+    // Only work with own properties.
+    if (Object.keys(b).length === 0) {
+      return;
+    }
+
+    this.data = {};
+    b = collapse(b);
+  
+    const options = {
+      hostname: this.broker,
+      port: 443,
+      path: '/module/httptrap/' + this.uuid + '/' + this.secret,
+      method: 'PUT',
+    };
+  
+    // If using default host, include the self-signed certificate
+    if (options.hostname === defaultBroker) {
+      options.ca = getDefaultCa();
+    }
+  
+    const req = https.request(options, (res) => {
+      let backside = '';
+
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        backside += chunk;
+      });
+
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          let sError;
+
+          try {
+            const obj = JSON.parse(backside);
+            sError = obj.error;
+          } catch (err) { }
+
+          if (!sError) {
+            sError = 'status ' + res.statusCode;
+          }
+
+          this.emit('error', new Error(sError));
+        }
+      });
+    });
+
+    req.on('error', (err) => {
+      if (this.throwErrors) {
+        throw err;
+      }
+    });
+
+    const payload = JSON.stringify(b);
+    // Set Content-Length to avoid using chunked encoding
+    req.setHeader('Content-Length', Buffer.byteLength(payload));
+    req.write(payload);
+    req.end();
+  }
+}
+
+
+function collapse(obj) {
+  const newobj = {};
+  const keys = Object.keys(obj);  // Loop over own properties.
+
+  for (let i = 0; i < keys.length; i++) {
+    const k = keys[i];
+    const v = obj[k];
+
+    if (typeof v === 'object') {
+      if (k === '_value') {
+        newobj[k] = Object.keys(v).map((hkey) => {
+          return hkey + '=' + v[hkey];
+        });
+      } else {
+        newobj[k] = collapse(v);
+      }
+    } else {
+      newobj[k] = v;
+    }
+  }
+
   return newobj;
 }
+
+
 function normalize(vOrig) {
-  var v = vOrig, vString = '', exp = 0;
-  if (v == 0) return 'H[0]';
+  let v = vOrig;
+  let vString = '';
+  let exp = 0;
+
+  if (v === 0) {
+    return 'H[0]';
+  }
+
   if (v < 0) {
     vString = '-';
-    v = v * -1;
+    v = -v;
   }
+
   while (v < 10) {
     v = v * 10;
     exp = exp - 1;
   }
+
   while (v >= 100) {
     v = v / 10;
     exp = exp + 1;
   }
+
   v = Math.floor(v);
   v = v / 10;
   exp = exp + 1;
-  vString = 'H[' + vString + v.toString() + 'e' + exp.toString() + ']';
+  vString = 'H[' + vString + v + 'e' + exp + ']';
   return vString;
 }
-trap.prototype.record = function(endpoint, value) {
-  if(!this.data.hasOwnProperty(endpoint)) this.data[endpoint] = { '_type': 'n', '_value': { } };
-  var vString = normalize(value);
-  if(!this.data[endpoint]._value.hasOwnProperty(vString))
-    this.data[endpoint]._value[vString] = 1;
-  else
-    this.data[endpoint]._value[vString] = this.data[endpoint]._value[vString] + 1;
-}
 
-trap.prototype.push = function() {
-  var lThis = this,
-      b = this.data,
-      doit = false;
-  this.data = {};
-  for (var k in b) {
-    if(b.hasOwnProperty(k)) {
-      doit = true;
-      break;
-    }
+
+function getDefaultCa() {
+  if (defaultCa === undefined) {
+    defaultCa = "-----BEGIN CERTIFICATE-----\n" +
+    "MIID4zCCA0ygAwIBAgIJAMelf8skwVWPMA0GCSqGSIb3DQEBBQUAMIGoMQswCQYD\n" +
+    "VQQGEwJVUzERMA8GA1UECBMITWFyeWxhbmQxETAPBgNVBAcTCENvbHVtYmlhMRcw\n" +
+    "FQYDVQQKEw5DaXJjb251cywgSW5jLjERMA8GA1UECxMIQ2lyY29udXMxJzAlBgNV\n" +
+    "BAMTHkNpcmNvbnVzIENlcnRpZmljYXRlIEF1dGhvcml0eTEeMBwGCSqGSIb3DQEJ\n" +
+    "ARYPY2FAY2lyY29udXMubmV0MB4XDTA5MTIyMzE5MTcwNloXDTE5MTIyMTE5MTcw\n" +
+    "NlowgagxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMI\n" +
+    "Q29sdW1iaWExFzAVBgNVBAoTDkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJj\n" +
+    "b251czEnMCUGA1UEAxMeQ2lyY29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4w\n" +
+    "HAYJKoZIhvcNAQkBFg9jYUBjaXJjb251cy5uZXQwgZ8wDQYJKoZIhvcNAQEBBQAD\n" +
+    "gY0AMIGJAoGBAKz2X0/0vJJ4ad1roehFyxUXHdkjJA9msEKwT2ojummdUB3kK5z6\n" +
+    "PDzDL9/c65eFYWqrQWVWZSLQK1D+v9xJThCe93v6QkSJa7GZkCq9dxClXVtBmZH3\n" +
+    "hNIZZKVC6JMA9dpRjBmlFgNuIdN7q5aJsv8VZHH+QrAyr9aQmhDJAmk1AgMBAAGj\n" +
+    "ggERMIIBDTAdBgNVHQ4EFgQUyNTsgZHSkhhDJ5i+6IFlPzKYxsUwgd0GA1UdIwSB\n" +
+    "1TCB0oAUyNTsgZHSkhhDJ5i+6IFlPzKYxsWhga6kgaswgagxCzAJBgNVBAYTAlVT\n" +
+    "MREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMIQ29sdW1iaWExFzAVBgNVBAoT\n" +
+    "DkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJjb251czEnMCUGA1UEAxMeQ2ly\n" +
+    "Y29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4wHAYJKoZIhvcNAQkBFg9jYUBj\n" +
+    "aXJjb251cy5uZXSCCQDHpX/LJMFVjzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEB\n" +
+    "BQUAA4GBAAHBtl15BwbSyq0dMEBpEdQYhHianU/rvOMe57digBmox7ZkPEbB/baE\n" +
+    "sYJysziA2raOtRxVRtcxuZSMij2RiJDsLxzIp1H60Xhr8lmf7qF6Y+sZl7V36KZb\n" +
+    "n2ezaOoRtsQl9dhqEMe8zgL76p9YZ5E69Al0mgiifTteyNjjMuIW\n" +
+    "-----END CERTIFICATE-----\n"
   }
-  if(!doit) return;
-  b = collapse(b);
 
-  var options = {
-    hostname: this.broker,
-    port: 443,
-    path: '/module/httptrap/' + this.uuid + '/' + this.secret,
-    method: 'PUT',
-  };
-
-  // If using default host, include the self-signed certificate
-  if(options.hostname == defaultBroker) {
-    options.ca = 
-"-----BEGIN CERTIFICATE-----\n" +
-"MIID4zCCA0ygAwIBAgIJAMelf8skwVWPMA0GCSqGSIb3DQEBBQUAMIGoMQswCQYD\n" +
-"VQQGEwJVUzERMA8GA1UECBMITWFyeWxhbmQxETAPBgNVBAcTCENvbHVtYmlhMRcw\n" +
-"FQYDVQQKEw5DaXJjb251cywgSW5jLjERMA8GA1UECxMIQ2lyY29udXMxJzAlBgNV\n" +
-"BAMTHkNpcmNvbnVzIENlcnRpZmljYXRlIEF1dGhvcml0eTEeMBwGCSqGSIb3DQEJ\n" +
-"ARYPY2FAY2lyY29udXMubmV0MB4XDTA5MTIyMzE5MTcwNloXDTE5MTIyMTE5MTcw\n" +
-"NlowgagxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMI\n" +
-"Q29sdW1iaWExFzAVBgNVBAoTDkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJj\n" +
-"b251czEnMCUGA1UEAxMeQ2lyY29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4w\n" +
-"HAYJKoZIhvcNAQkBFg9jYUBjaXJjb251cy5uZXQwgZ8wDQYJKoZIhvcNAQEBBQAD\n" +
-"gY0AMIGJAoGBAKz2X0/0vJJ4ad1roehFyxUXHdkjJA9msEKwT2ojummdUB3kK5z6\n" +
-"PDzDL9/c65eFYWqrQWVWZSLQK1D+v9xJThCe93v6QkSJa7GZkCq9dxClXVtBmZH3\n" +
-"hNIZZKVC6JMA9dpRjBmlFgNuIdN7q5aJsv8VZHH+QrAyr9aQmhDJAmk1AgMBAAGj\n" +
-"ggERMIIBDTAdBgNVHQ4EFgQUyNTsgZHSkhhDJ5i+6IFlPzKYxsUwgd0GA1UdIwSB\n" +
-"1TCB0oAUyNTsgZHSkhhDJ5i+6IFlPzKYxsWhga6kgaswgagxCzAJBgNVBAYTAlVT\n" +
-"MREwDwYDVQQIEwhNYXJ5bGFuZDERMA8GA1UEBxMIQ29sdW1iaWExFzAVBgNVBAoT\n" +
-"DkNpcmNvbnVzLCBJbmMuMREwDwYDVQQLEwhDaXJjb251czEnMCUGA1UEAxMeQ2ly\n" +
-"Y29udXMgQ2VydGlmaWNhdGUgQXV0aG9yaXR5MR4wHAYJKoZIhvcNAQkBFg9jYUBj\n" +
-"aXJjb251cy5uZXSCCQDHpX/LJMFVjzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEB\n" +
-"BQUAA4GBAAHBtl15BwbSyq0dMEBpEdQYhHianU/rvOMe57digBmox7ZkPEbB/baE\n" +
-"sYJysziA2raOtRxVRtcxuZSMij2RiJDsLxzIp1H60Xhr8lmf7qF6Y+sZl7V36KZb\n" +
-"n2ezaOoRtsQl9dhqEMe8zgL76p9YZ5E69Al0mgiifTteyNjjMuIW\n" +
-"-----END CERTIFICATE-----\n"
-  };
-
-  var req = https.request(options, function(res) {
-    res.setEncoding('utf8');
-    var backside = '';
-    res.on('data', function (chunk) {
-      backside = backside + chunk;
-    });
-    res.on('end', function() {
-      if(res.statusCode != 200) {
-        var sError;
-        try {
-          var obj = JSON.parse(backside);
-          sError = obj.error;
-        } catch(e) { }
-        if(!sError) sError = "status " + res.statusCode;
-        lThis.emit('error', sError);
-      }
-    });
-  });
-  var throwErrors = this.throwErrors;
-  req.on('error', function(e) {
-    if(throwErrors) throw(e);
-  });
-  var payload = JSON.stringify(b);
-  // Set Content-Length to avoid using chunked encoding
-  req.setHeader('Content-Length', Buffer.byteLength(payload));
-  req.write(payload);
-  req.end();
+  return defaultCa;
 }
 
-trap.prototype.publish = function(interval) {
-  if(interval !== 0 && !interval) interval = 500;
-  if(this._pubint) clearInterval(this._pubint);
-  if(interval != 0) {
-    this._pubint = (function(lThis) { setInterval(function() { lThis.push() }, 500); })(this);
+
+function target(uuid, secret, options) {
+  let key = uuid + '/' + secret;
+
+  if (options && options.broker) {
+    key = key + '/' + options.broker;
   }
+
+  if (traps.hasOwnProperty(key)) {
+    return traps[key];
+  }
+
+  traps[key] = new Trap(uuid, secret, options);
+  return traps[key];
 }
+
 
 module.exports = target;

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -2,5 +2,5 @@ module.exports = {
   makeTrap: require('./httptrap'),
   express: require('./express'),
   restify: require('./restify'),
-  hapi: require('./hapi')
+  hapi: require('./hapi/legacy')
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "files": [
     "express.js",
-    "hapi.js",
+    "hapi/legacy.js",
     "httptrap.js",
     "index.js",
     "restify.js"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "files": [
     "express.js",
+    "hapi/index.js",
     "hapi/legacy.js",
     "httptrap.js",
     "index.js",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -3,8 +3,15 @@
   "version": "1.0.5",
   "description": "Circonus Instrumentation Package for Node.js",
   "main": "index.js",
+  "files": [
+    "express.js",
+    "hapi.js",
+    "httptrap.js",
+    "index.js",
+    "restify.js"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "lab -v -t 100 -l"
   },
   "repository": {
     "type": "git",
@@ -24,5 +31,10 @@
   "dependencies": {
     "on-finished": "^2.3.0",
     "on-headers": "^1.0.1"
+  },
+  "devDependencies": {
+    "lab": "14.x.x",
+    "stand-in": "4.x.x",
+    "uuid": "3.x.x"
   }
 }

--- a/nodejs/test/httptrap.js
+++ b/nodejs/test/httptrap.js
@@ -1,0 +1,228 @@
+'use strict';
+const assert = require('assert');
+const events = require('events');
+const http = require('http');
+const https = require('https');
+const lab = exports.lab = require('lab').script();
+const uuid = require('uuid');
+const standin = require('stand-in');
+const httptrap = require('../httptrap');
+const { describe, it } = lab;
+
+describe('httptrap', () => {
+  it('trap inherits from EventEmitter', (done) => {
+    const id = uuid();
+    const secret = uuid();
+    const broker = uuid();
+    const trap = httptrap(id, secret, { broker, throwErrors: true });
+
+    assert.strictEqual(trap instanceof events.EventEmitter, true);
+    assert.strictEqual(trap.uuid, id);
+    assert.strictEqual(trap.secret, secret);
+    assert.strictEqual(trap.broker, broker);
+    assert.strictEqual(trap.throwErrors, true);
+    assert.deepStrictEqual(trap.data, {});
+    done();
+  });
+
+  it('repeat keys return the same trap', (done) => {
+    const id = uuid();
+    const broker = uuid();
+    const trap1 = httptrap(id, 'secret', { broker });
+    const trap2 = httptrap(id, 'secret', { broker });
+
+    assert.strictEqual(trap1, trap2);
+    done();
+  });
+
+  it('differentiates between brokers', (done) => {
+    const id = uuid();
+    const broker = uuid();
+    const trap1 = httptrap(id, 'secret'); // Uses the default broker.
+    const trap2 = httptrap(id, 'secret', { broker });
+
+    assert.notStrictEqual(trap1, trap2);
+    done();
+  });
+
+  it('records data', (done) => {
+    const id = uuid();
+    const trap = httptrap(id, id, { broker: id });
+
+    trap.record('foo', -5);
+    trap.record('foo', 0);
+    trap.record('foo', 0);
+    trap.record('foo', 5);
+    trap.record('foo', 150);
+    trap.record('foo', 1250);
+    assert.deepStrictEqual(trap.data, {
+      foo: {
+        _type: 'n',
+        _value: {
+          'H[-5e0]': 1,
+          'H[0]': 2,
+          'H[5e0]': 1,
+          'H[1.5e2]': 1,
+          'H[1.2e3]': 1
+        }
+      }
+    });
+    done();
+  });
+
+  it('pushing does nothing if there is no data to send', (done) => {
+    const id = uuid();
+    const trap = httptrap(id, id, { broker: id });
+    const data = trap.data;
+
+    assert.deepStrictEqual(data, {});
+    trap.push();
+    assert.strictEqual(trap.data, data);
+    done();
+  });
+
+  it('pushes data to the default broker', (done) => {
+    const { server, trap } = mockServer(null, (req, res) => {
+      res.end();
+      server.close();
+      done();
+    }, () => {
+      trap.record('foo', -5);
+      trap.push();
+    });
+  });
+
+  it('pushes data to a custom broker', (done) => {
+    const { server, trap } = mockServer({ broker: uuid() }, (req, res) => {
+      res.end();
+      server.close();
+      done();
+    }, () => {
+      trap.record('foo', -5);
+      trap.push();
+    });
+  });
+
+  it('handles errors when pushing to the server', (done) => {
+    const { server, trap } = mockServer(null, (req, res) => {
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: 'Internal Server Error' }));
+    }, () => {
+      trap.on('error', (err) => {
+        server.close();
+        assert.strictEqual(err.message, 'Internal Server Error');
+        done();
+      });
+
+      trap.record('foo', -5);
+      trap.push();
+    });
+  });
+
+  it('reports HTTP status code if error is missing/invalid', (done) => {
+    const { server, trap } = mockServer(null, (req, res) => {
+      res.writeHead(501);
+      res.end();
+    }, () => {
+      trap.on('error', (err) => {
+        server.close();
+        assert.strictEqual(err.message, 'status 501');
+        done();
+      });
+
+      trap.record('foo', -5);
+      trap.push();
+    });
+  });
+
+  it('swallows request errors by default', (done) => {
+    const { server, trap } = mockServer({
+      broker: 'abcdefghi'
+    }, (req, res) => {
+      assert.fail('this should not be called');
+    }, () => {
+      server.close();
+      trap.record('foo', -5);
+      trap.push();
+      setImmediate(done);
+    });
+  });
+
+  it('throws asynchronous request errors when throwErrors is true', (done) => {
+    const domain = require('domain');
+    const d = domain.create();
+
+    d.on('error', (err) => {
+      done();
+    });
+
+    d.run(() => {
+      try {
+        const { server, trap } = mockServer({
+          broker: 'abcdefghi',
+          throwErrors: true
+        }, (req, res) => {
+          assert.fail('this should not be called');
+        }, () => {
+          server.close();
+          trap.record('foo', -5);
+          trap.push();
+        });
+      } catch (err) {
+        assert.fail('should not be able to catch error');
+      }
+    });
+  });
+
+  it('publishing utilizes an interval', (done) => {
+    const id = uuid();
+    const trap = httptrap(id, id, { broker: id });
+
+    standin.replaceOnce(trap, 'push', () => {
+      clearInterval(trap._pubint);
+      done();
+    });
+
+    assert.strictEqual(trap._pubint, undefined);
+    trap.publish();
+    const interval = trap._pubint;
+    assert.notStrictEqual(interval, undefined);
+    trap.publish(0);    // interval should not change if value is 0.
+    assert.strictEqual(trap._pubint, interval);
+    trap.publish(10);   // interval changes if value is different.
+    assert.notStrictEqual(trap._pubint, interval);
+  });
+});
+
+
+function mockServer(options, onRequest, onListen) {
+  const id = uuid();
+  const secret = uuid();
+  const trap = httptrap(id, secret, options);
+  const server = http.createServer(onRequest);
+
+  standin.replaceOnce(https, 'request', (stand, options, callback) => {
+    assert.strictEqual(options.hostname, trap.broker);
+    assert.strictEqual(options.port, 443);
+    assert.strictEqual(options.path, '/module/httptrap/' + id + '/' + secret);
+    assert.strictEqual(options.method, 'PUT');
+
+    if (trap.broker === 'trap.noit.circonus.net') {
+      assert.strictEqual(typeof options.ca, 'string');
+    } else {
+      assert.strictEqual(typeof options.ca, 'undefined');
+    }
+
+    const address = server.address();
+
+    if (address) {
+      options.hostname = address.address;
+      options.port = address.port;
+    }
+
+    return http.request(options, callback);
+  });
+
+  server.listen(0, onListen);
+  return { server, trap };
+}


### PR DESCRIPTION
This PR does the following in separate commits:

- Cleans up the code in httptrap.js and adds tests for it (100% code coverage via `npm test`). Also cleaned up a few bugs. Nothing should change from a user perspective.
- Moves the existing hapi.js module to `hapi/legacy.js`. The version of hapi that was being supported is now considered legacy. Nothing should change from a user perspective.
- Adds `hapi/index.js` for hapi 17 support. To use it, users would `require('circonus-cir/hapi')`. If it were automatically exposed, it would break for users on Node < 8. This is due to new language features used by hapi 17.