### PR TITLE
allow agent to be created from hapi plugin

### DIFF
--- a/nodejs/hapi/index.js
+++ b/nodejs/hapi/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const makeAgent = require('../agent');
 const makeTrap = require('../httptrap');
 const pkg = require('../package.json');
 const startSymbol = Symbol('circonusStartTime');
@@ -6,7 +7,13 @@ function noop() {}
 
 
 function register(server, options) {
-  const trap = makeTrap(options.uuid, options.secret, options);
+  let trap;
+
+  if (options.agentURL) {
+    trap = makeAgent(options.agentURL);
+  } else {
+    trap = makeTrap(options.uuid, options.secret, options);
+  }
 
   if (options.onError) {
     trap.on('error', options.onError);


### PR DESCRIPTION
Since `httptrap` and `agent` have the same interface, is there any reason not to let the framework plugins work the same way? Otherwise, I think `agent` users would need to write their own plugins.

I also noticed that the implementations of `httptrap` and `agent` seem to be mostly duplicated (the constructor and `push()` are different). If that's intentional, maybe one could inherit from the other to reduce duplicate code?
