### PR TITLE
add agent.js to npm whitelist

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -4,6 +4,7 @@
   "description": "Circonus Instrumentation Package for Node.js",
   "main": "index.js",
   "files": [
+    "agent.js",
     "express.js",
     "hapi/index.js",
     "hapi/legacy.js",


### PR DESCRIPTION
v1.1.1 throws when trying to `require()` the new `agent.js` file added in https://github.com/circonus-labs/circonus-cip/pull/3 because it's not part of the npm whitelist.